### PR TITLE
Bump version to v2.4.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#f77190fd7e994622ac09084b9326ad85a62629f3",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#3964a811ed",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tchap-web",
   "productName": "Tchap",
   "main": "electron_app/src/electron-main.js",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "description": "A feature-rich client for Matrix.org",
   "author": "MinArm/DINUM/matrix.org",
   "repository": {
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#a02047475e",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#8e910e0490",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tchap-web",
   "productName": "Tchap",
   "main": "electron_app/src/electron-main.js",
-  "version": "2.4.0",
+  "version": "2.4.0-rc.1",
   "description": "A feature-rich client for Matrix.org",
   "author": "MinArm/DINUM/matrix.org",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#8e910e0490",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#f77190fd7e994622ac09084b9326ad85a62629f3",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -26,7 +26,7 @@ import Promise from 'bluebird';
 import url from 'url';
 import UAParser from 'ua-parser-js';
 
-const POKE_RATE_MS = 10 * 60 * 1000; // 10 min
+const POKE_RATE_MS = 0.5 * 60 * 1000; // 0.5min = 30s
 
 export default class WebPlatform extends VectorBasePlatform {
     constructor() {

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -26,7 +26,7 @@ import Promise from 'bluebird';
 import url from 'url';
 import UAParser from 'ua-parser-js';
 
-const POKE_RATE_MS = 0.5 * 60 * 1000; // 0.5min = 30s
+const POKE_RATE_MS = 10 * 60 * 1000; // 10 min
 
 export default class WebPlatform extends VectorBasePlatform {
     constructor() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,9 +6124,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#8e910e0490":
-  version "2.4.0-tchap"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/8e910e049039894e69d2fbfc130b474491b6a4db"
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#f77190fd7e994622ac09084b9326ad85a62629f3":
+  version "2.4.0-tchap-rc.1"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/f77190fd7e994622ac09084b9326ad85a62629f3"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,9 +6124,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#a02047475e":
-  version "2.3.7-tchap"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/a02047475e58c88838ec29e87e8b046a5fd04a56"
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#8e910e0490":
+  version "2.4.0-tchap"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/8e910e049039894e69d2fbfc130b474491b6a4db"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,9 +6124,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#f77190fd7e994622ac09084b9326ad85a62629f3":
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#3964a811ed":
   version "2.4.0-tchap-rc.1"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/f77190fd7e994622ac09084b9326ad85a62629f3"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/3964a811ed897fc594f7b68ba836c6fc233c1e06"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
The accurate version numbers are needed for the upgrade banner to appear. https://github.com/tchapgouv/tchap-web/issues/183