### PR TITLE
Fix permalinks in preprod

### DIFF
--- a/config.json
+++ b/config.json
@@ -20,11 +20,11 @@
     },
     "terms_and_conditions_links": [
         {
-            "url": "https://tchap.gouv.fr/tac/",
+            "url": "https://app.preprod.tchap.incubateur.net/tac/",
             "text": "Conditions générales d'utilisation"
         }
     ],
-    "base_host_url": "https://tchap.gouv.fr",
+    "base_host_url": "https://app.preprod.tchap.incubateur.net",
     "generic_endpoints": {
         "faq": "/faq/",
         "tac": "/tac/",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -20,11 +20,11 @@
     },
     "terms_and_conditions_links": [
         {
-            "url": "https://tchap.gouv.fr/tac/",
+            "url": "https://app.preprod.tchap.incubateur.net/tac/",
             "text": "Conditions générales d'utilisation"
         }
     ],
-    "base_host_url": "https://tchap.gouv.fr",
+    "base_host_url": "https://app.preprod.tchap.incubateur.net",
     "generic_endpoints": {
         "faq": "/faq/",
         "tac": "/tac/",


### PR DESCRIPTION
So that they point to the preprod scalingo instance.

Close https://github.com/tchapgouv/tchap-web/issues/203