### PR TITLE
Rediriger le mobile vers https://tchap.beta.gouv.fr au lieu du mobile guide

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -33,7 +33,7 @@
         "export_info": "/faq/#tcq03_002",
         "mobile_info": "/faq/#tcq06_002",
         "browser_session_info": "/faq/#tcq03_002",
-        "mobile_download": "/mobile_guide"
+        "mobile_download": "/landing"
     },
     "branding": {
         "authFooterLinks": [

--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
         "export_info": "/faq/#tcq03_002",
         "mobile_info": "/faq/#tcq06_002",
         "browser_session_info": "/faq/#tcq03_002",
-        "mobile_download": "/mobile_guide"
+        "mobile_download": "/landing"
     },
     "branding": {
         "authFooterLinks": [

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -33,7 +33,7 @@
         "export_info": "/faq/#tcq03_002",
         "mobile_info": "/faq/#tcq06_002",
         "browser_session_info": "/faq/#tcq03_002",
-        "mobile_download": "/mobile_guide"
+        "mobile_download": "/landing"
     },
     "branding": {
         "authFooterLinks": [

--- a/config.prod.json
+++ b/config.prod.json
@@ -33,7 +33,7 @@
         "export_info": "/faq/#tcq03_002",
         "mobile_info": "/faq/#tcq06_002",
         "browser_session_info": "/faq/#tcq03_002",
-        "mobile_download": "https://tchap.beta.gouv.fr"
+        "mobile_download": "/landing"
     },
     "branding": {
         "authFooterLinks": [

--- a/config.prod.json
+++ b/config.prod.json
@@ -33,7 +33,7 @@
         "export_info": "/faq/#tcq03_002",
         "mobile_info": "/faq/#tcq06_002",
         "browser_session_info": "/faq/#tcq03_002",
-        "mobile_download": "/mobile_guide"
+        "mobile_download": "https://tchap.beta.gouv.fr"
     },
     "branding": {
         "authFooterLinks": [


### PR DESCRIPTION
Actuellement en mobile, l'utilisateur est rediriger sur page avec des erreurs, je propose de rediriger vers la landing à la place
Fix #142