### PR TITLE
Fix contact link

### DIFF
--- a/config.beta.json
+++ b/config.beta.json
@@ -42,7 +42,7 @@
             {"text": "Gouvernement", "url": "https://www.gouvernement.fr/"},
             {"text": "OpenData", "url": "https://www.data.gouv.fr/fr/"},
             {"text": "Mentions Légales", "url": "/tac/"},
-            {"text": "Contact", "url": "mailto:tchap@beta.gouv.fr"}
+            {"text": "Contact", "url": "https://tchap.beta.gouv.fr/#contact"}
         ]
     },
     "hs_url_list": [

--- a/config.dev.json
+++ b/config.dev.json
@@ -42,7 +42,7 @@
             {"text": "Gouvernement", "url": "https://www.gouvernement.fr/"},
             {"text": "OpenData", "url": "https://www.data.gouv.fr/fr/"},
             {"text": "Mentions Légales", "url": "/tac/"},
-            {"text": "Contact", "url": "mailto:tchap@beta.gouv.fr"}
+            {"text": "Contact", "url": "https://tchap.beta.gouv.fr/#contact"}
         ]
     },
     "hs_url_list": [

--- a/config.json
+++ b/config.json
@@ -42,7 +42,7 @@
             {"text": "Gouvernement", "url": "https://www.gouvernement.fr/"},
             {"text": "OpenData", "url": "https://www.data.gouv.fr/fr/"},
             {"text": "Mentions Légales", "url": "/tac/"},
-            {"text": "Contact", "url": "mailto:tchap@beta.gouv.fr"}
+            {"text": "Contact", "url": "https://tchap.beta.gouv.fr/#contact"}
         ]
     },
     "hs_url_list": [

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -42,7 +42,7 @@
             {"text": "Gouvernement", "url": "https://www.gouvernement.fr/"},
             {"text": "OpenData", "url": "https://www.data.gouv.fr/fr/"},
             {"text": "Mentions Légales", "url": "/tac/"},
-            {"text": "Contact", "url": "mailto:tchap@beta.gouv.fr"}
+            {"text": "Contact", "url": "https://tchap.beta.gouv.fr/#contact"}
         ]
     },
     "hs_url_list": [

--- a/config.prod.json
+++ b/config.prod.json
@@ -42,7 +42,7 @@
             {"text": "Gouvernement", "url": "https://www.gouvernement.fr/"},
             {"text": "OpenData", "url": "https://www.data.gouv.fr/fr/"},
             {"text": "Mentions Légales", "url": "/tac/"},
-            {"text": "Contact", "url": "mailto:tchap@beta.gouv.fr"}
+            {"text": "Contact", "url": "https://tchap.beta.gouv.fr/#contact"}
         ]
     },
     "hs_url_list": [


### PR DESCRIPTION
Le lien de contact de l'application devient un lien vers la landing : 
- Plus accessible qu'un mailto
- Toute l'information est au même endroit

Il n'y a aucun changement visuel sur la modification