### PR TITLE
Disable message history management on message composer

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#5a117f2cc7",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#879fca8f43e25ced41451f1489a1b431c552b8c0",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#879fca8f43e25ced41451f1489a1b431c552b8c0",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#629b3e8",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,9 +6125,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#879fca8f43e25ced41451f1489a1b431c552b8c0":
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#629b3e8":
   version "2.5.1-tchap"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/879fca8f43e25ced41451f1489a1b431c552b8c0"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/629b3e85f06b97fb2e1304e02a9666c02bd32d4b"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,9 +6125,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#5a117f2cc7":
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#879fca8f43e25ced41451f1489a1b431c552b8c0":
   version "2.5.1-tchap"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/5a117f2cc75ace722ce9e46aa03172543f7cccd7"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/879fca8f43e25ced41451f1489a1b431c552b8c0"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
When we use the "UP" key, the last message is retrieve, this cause user issue with message edition (The user do up key, thinking he will edit message but he just create a new message instead).
In this PR, I disable up and down key on message composer.

Linked to https://github.com/tchapgouv/matrix-react-sdk/pull/407
Fix #245