### PR TITLE
Monospace Font fixing + Emoji consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#c3d07eeddf547bc1359b948e6e59395ad6665f40",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#26ada09",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "gfm.css": "^1.1.2",
     "highlight.js": "^9.13.1",
     "matrix-js-sdk": "github:tchapgouv/matrix-js-sdk#1a0775cba",
-    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#5a117f2cc7",
+    "matrix-react-sdk": "github:tchapgouv/matrix-react-sdk#c3d07eeddf547bc1359b948e6e59395ad6665f40",
     "modernizr": "^3.6.0",
     "olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,9 +6125,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#5a117f2cc7":
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#c3d07eeddf547bc1359b948e6e59395ad6665f40":
   version "2.5.1-tchap"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/5a117f2cc75ace722ce9e46aa03172543f7cccd7"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/c3d07eeddf547bc1359b948e6e59395ad6665f40"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,9 +6125,9 @@ matrix-mock-request@^1.2.3:
     bluebird "^3.5.0"
     expect "^1.20.2"
 
-"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#c3d07eeddf547bc1359b948e6e59395ad6665f40":
+"matrix-react-sdk@github:tchapgouv/matrix-react-sdk#26ada09":
   version "2.5.1-tchap"
-  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/c3d07eeddf547bc1359b948e6e59395ad6665f40"
+  resolved "https://codeload.github.com/tchapgouv/matrix-react-sdk/tar.gz/26ada092e807aff6790ae8c816993368f995021b"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
The font inside code comment are incorrect.
This commit fix the font inconsolata that was loaded in the Tchap Theme. The fix is better for rebase purpose (but we will never rebase this version again ?)
Should also fix emoji on message (use the embedded emoji font instead of the system font)

Linked to https://github.com/tchapgouv/matrix-react-sdk/pull/408
Close #201

![image](https://user-images.githubusercontent.com/1238254/171755239-6a230b56-442e-4e93-b800-ea84195d1572.png)
Before -> after