### PR TITLE
fix : open existing dm

### DIFF
--- a/matrix-react-sdk/src/RoomInvite.js
+++ b/matrix-react-sdk/src/RoomInvite.js
@@ -275,7 +275,9 @@ function _selectDirectChat(userId) {
         const hisMembership = him.membership;
 
         const roomCreateEvent = room.currentState.getStateEvents("m.room.create");
-        const roomCreateEventDate = roomCreateEvent[0] ? roomCreateEvent[0].event.origin_server_ts : 0;
+        
+        //retrieve the date from the  unique create room event with the new structure : Array[Map:<String, Event>]
+        const roomCreateEventDate = roomCreateEvent[0] ? roomCreateEvent[0].values().next().value.event.origin_server_ts : 0;
 
         // Colliding all the "myMembership" and "hisMembership" possibilities.
 


### PR DESCRIPTION
fix : 
- TG_DM_2 : créer une dm qui existe déjà -> doit ouvrir la dm
- TG_GM_2 : envoyer un message à un utilisateur avec qui on possède une dm -> doit ouvrir la dm





`RoomInvite.js:341 Uncaught TypeError: Cannot read properties of undefined (reading 'origin_server_ts')
    at RoomInvite.js:341:81
    at Array.forEach (<anonymous>)
    at RoomInvite.js:334:14
    at y (RoomInvite.js:174:24)
    at b (RoomInvite.js:243:9)
    at Object.l [as onFinished] (Modal.js:280:65)
    at t.onButtonClick (AddressPickerDialog.js:199:24)
    at Object.o (ReactErrorUtils.js:24:5)
    at s (EventPluginUtils.js:83:21)
    at Object.executeDispatchesInOrder (EventPluginUtils.js:106:5)
    at d (EventPluginHub.js:41:22)
    at f (EventPluginHub.js:52:10)
    at Array.forEach (<anonymous>)
    at e.exports (forEachAccumulated.js:22:9)
    at Object.processEventQueue (EventPluginHub.js:250:7)
    at ReactEventEmitterMixin.js:15:18
    at Object.handleTopLevel [as _handleTopLevel] (ReactEventEmitterMixin.js:25:5)
    at f (ReactEventListener.js:70:24)
    at u.perform (Transaction.js:141:20)
    at Object.batchedUpdates (ReactDefaultBatchingStrategy.js:60:26)
    at Object.batchedUpdates (ReactUpdates.js:95:27)
    at dispatchEvent (ReactEventListener.js:145:20)`
