### PR TITLE
Add Node JS 16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "webpack.config.js"
     ],
     "engines": {
-        "node": "14.17.3"
+        "node": ">= 14.17.3 < 17"
     },
     "style": "bundle.css",
     "matrix-react-parent": "matrix-react-sdk",


### PR DESCRIPTION
Builds are working. With that I don't need to switch Node versions between Tchap versions any more.