### PR TITLE
Add explicit userId prop to Pill

### DIFF
--- a/matrix-react-sdk/src/components/views/elements/Pill.js
+++ b/matrix-react-sdk/src/components/views/elements/Pill.js
@@ -63,6 +63,8 @@ const Pill = React.createClass({
         shouldShowPillAvatar: PropTypes.bool,
         // Whether to render this pill as if it were highlit by a selection
         isSelected: PropTypes.bool,
+        // explicit userId
+        userId: PropTypes.string,
     },
 
 
@@ -102,7 +104,10 @@ const Pill = React.createClass({
         let resourceId;
         let prefix;
 
-        if (nextProps.url) {
+        if (nextProps.userId) {
+            resourceId = nextProps.userId;
+            prefix = "@";
+        } else if (nextProps.url) {
             // Default to the empty array if no match for simplicity
             // resource and prefix will be undefined instead of throwing
             matrixToMatch = regex.exec(nextProps.url) || [];
@@ -275,7 +280,7 @@ const Pill = React.createClass({
             "mx_UserPill_selected": this.props.isSelected,
         });
 
-        const member = this.state.member
+        const member = this.state.member;
         const displayName = member ? member.rawDisplayName : '';
 
         if (this.state.pillType) {

--- a/matrix-react-sdk/src/components/views/elements/ReplyThread.js
+++ b/matrix-react-sdk/src/components/views/elements/ReplyThread.js
@@ -270,6 +270,7 @@ export default class ReplyThread extends React.Component {
                 }
             </blockquote>;
         } else if (this.state.loadedEv) {
+            /** @type {MatrixEvent} */
             const ev = this.state.loadedEv;
             const Pill = sdk.getComponent('elements.Pill');
             const room = this.context.matrixClient.getRoom(ev.getRoomId());
@@ -277,7 +278,7 @@ export default class ReplyThread extends React.Component {
                 {
                     _t('<a>In reply to</a> <pill>', {}, {
                         'a': (sub) => <a onClick={this.onQuoteClick} className="mx_ReplyThread_show">{ sub }</a>,
-                        'pill': <Pill type={Pill.TYPE_USER_MENTION} room={room}
+                        'pill': <Pill type={Pill.TYPE_USER_MENTION} userId={ev.getSender()} room={room}
                                       url={makeUserPermalink(ev.getSender())} shouldShowPillAvatar={true} />,
                     })
                 }


### PR DESCRIPTION
Targeting the reply-reply issue:

![image](https://user-images.githubusercontent.com/6216686/188803701-4c6079ec-6170-4981-9a26-b3c8605bba39.png)

I don't think the Map migration caused the problem. Instead [this regex](https://github.com/tchapgouv/tchap-web/blob/develop/matrix-react-sdk/src/components/views/elements/Pill.js#L27) doesn't cover all environments.

Quick fixing by passing the user ID explicitly.