### PR TITLE
Fix undefined vars in RoomInvite

### DIFF
--- a/matrix-react-sdk/src/RoomInvite.js
+++ b/matrix-react-sdk/src/RoomInvite.js
@@ -115,6 +115,8 @@ export function isValid3pidInvite(event) {
 function _inviteToChat(invitedUserId) {
     const selectedRoom = _selectDirectChat(invitedUserId);
     const roomStatus = selectedRoom ? selectedRoom.status : null;
+    const ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
+    const matrixClient = MatrixClientPeg.get();
 
     switch (roomStatus) {
         case "join-join":
@@ -150,7 +152,7 @@ function _inviteToChat(invitedUserId) {
 
         case "join-leave":
             // Send an invitation then redirect to the existing room.
-            _inviteToRoom(selectedRoom.room.roomId, addrText);
+            _inviteToRoom(selectedRoom.room.roomId, invitedUserId);
             dis.dispatch({
                 action: 'view_room',
                 room_id: selectedRoom.room.roomId,


### PR DESCRIPTION
While testing creating DMs and double DMs, I got the error `addrText is not defined` in a modal. 

Looks like a bad refactor introduced in this commit, 2 yrs ago : https://github.com/tchapgouv/matrix-react-sdk/commit/209084b3db5ccc465ae2f4eb33cecb998345b16a

I can't reproduce it any more, I'm not sure how to trigger this code path. But I figured we could fix it anyway...